### PR TITLE
Added filtering possibilities for SP:s

### DIFF
--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>se.swedenconnect.spring.saml.idp</groupId>
     <artifactId>spring-saml-idp-parent</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Spring SAML Identity Provider :: Spring Boot Autoconfigure module</name>

--- a/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/IdentityProviderAutoConfiguration.java
+++ b/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/IdentityProviderAutoConfiguration.java
@@ -15,11 +15,7 @@
  */
 package se.swedenconnect.spring.saml.idp.autoconfigure.settings;
 
-import java.security.cert.X509Certificate;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import lombok.Setter;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -30,10 +26,10 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
-
-import lombok.Setter;
 import se.swedenconnect.security.credential.PkiCredential;
+import se.swedenconnect.spring.saml.idp.authnrequest.Saml2ServiceProviderFilter;
 import se.swedenconnect.spring.saml.idp.config.configurers.Saml2IdpConfigurer;
+import se.swedenconnect.spring.saml.idp.config.configurers.Saml2IdpConfigurerAdapter;
 import se.swedenconnect.spring.saml.idp.events.Saml2IdpEventPublisher;
 import se.swedenconnect.spring.saml.idp.settings.AssertionSettings;
 import se.swedenconnect.spring.saml.idp.settings.CredentialSettings;
@@ -42,6 +38,11 @@ import se.swedenconnect.spring.saml.idp.settings.IdentityProviderSettings;
 import se.swedenconnect.spring.saml.idp.settings.MetadataSettings;
 import se.swedenconnect.spring.saml.idp.settings.MetadataSettings.EncryptionMethodSettings;
 import se.swedenconnect.spring.saml.idp.settings.MetadataSettings.SigningMethodSettings;
+
+import java.security.cert.X509Certificate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Configuration class for Identity Provider general settings.
@@ -219,6 +220,16 @@ public class IdentityProviderAutoConfiguration {
   @Bean
   Saml2IdpEventPublisher saml2IdpEventPublisher(final ApplicationEventPublisher applicationEventPublisher) {
     return new Saml2IdpEventPublisher(applicationEventPublisher);
+  }
+
+  @Bean
+  Saml2IdpConfigurerAdapter defaultServiceProviderFilterConfiguration(
+      @Autowired(required = false) final Saml2ServiceProviderFilter serviceProviderFilter) {
+
+    return (h, c) -> c.authnRequestProcessor(a -> a.authenticationProvider(
+        f -> f.serviceProviderFilter(serviceProviderFilter != null
+            ? serviceProviderFilter
+            : entityDescriptor -> true)));
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.swedenconnect.spring.saml.idp</groupId>
   <artifactId>spring-saml-idp-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.4</version>
+  <version>2.2.0-SNAPSHOT</version>
 
   <name>Sweden Connect :: Spring SAML Identity Provider :: Parent POM</name>
   <description>Parent POM for Spring SAML Identity Provider libraries</description>
@@ -280,19 +280,6 @@
         </plugin>
 
         <plugin>
-          <groupId>org.projectlombok</groupId>
-          <artifactId>lombok-maven-plugin</artifactId>
-          <version>1.18.20.0</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.projectlombok</groupId>
-              <artifactId>lombok</artifactId>
-              <version>${lombok.version}</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>4.0.0-M8</version>
@@ -388,15 +375,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok-maven-plugin</artifactId>
-        <configuration>
-          <addOutputDirectory>false</addOutputDirectory>
-          <sourceDirectory>src/main/java</sourceDirectory>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
       </plugin>
@@ -442,19 +420,6 @@
         <plugins>
 
           <plugin>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>delombok</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
             <executions>
@@ -492,9 +457,6 @@
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <sourcepath>target/generated-sources/delombok</sourcepath>
-            </configuration>
           </plugin>
 
           <plugin>

--- a/saml-identity-provider/pom.xml
+++ b/saml-identity-provider/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.swedenconnect.spring.saml.idp</groupId>
     <artifactId>spring-saml-idp-parent</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Spring SAML Identity Provider :: Core Library</name>

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/Saml2IdentityProviderVersion.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/Saml2IdentityProviderVersion.java
@@ -23,8 +23,8 @@ package se.swedenconnect.spring.saml.idp;
 public final class Saml2IdentityProviderVersion {
 
   private static final int MAJOR = 2;
-  private static final int MINOR = 1;
-  private static final int PATCH = 4;
+  private static final int MINOR = 2;
+  private static final int PATCH = 0;
 
   /**
    * Global serialization value for SAML Identity Provider classes.

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2AuthnRequestAuthenticationProvider.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2AuthnRequestAuthenticationProvider.java
@@ -103,6 +103,9 @@ public class Saml2AuthnRequestAuthenticationProvider implements AuthenticationPr
   /** The {@link NameIDGeneratorFactory} to use when creating a {@link NameIDGenerator} instance. */
   private final NameIDGeneratorFactory nameIDGeneratorFactory;
 
+  /** Filter for checking whether a SP is acceptable. */
+  private final Saml2ServiceProviderFilter serviceProviderFilter;
+
   /**
    * Constructor. See {@link Saml2AuthnRequestAuthenticationProviderConfigurer} for how to configuration and setup.
    *
@@ -114,6 +117,7 @@ public class Saml2AuthnRequestAuthenticationProvider implements AuthenticationPr
    * @param requestedAttributesProcessors extracts the requested attributes
    * @param nameIDGeneratorFactory the {@link NameIDGeneratorFactory} to use when creating a {@link NameIDGenerator}
    *     instance
+   * @param serviceProviderFilter filter for checking whether a SP is acceptable
    */
   public Saml2AuthnRequestAuthenticationProvider(
       final Saml2IdpEventPublisher eventPublisher,
@@ -122,9 +126,11 @@ public class Saml2AuthnRequestAuthenticationProvider implements AuthenticationPr
       final AuthnRequestValidator replayValidator,
       final AuthnRequestValidator encryptCapabilitiesValidator,
       final List<RequestedAttributeProcessor> requestedAttributesProcessors,
-      final NameIDGeneratorFactory nameIDGeneratorFactory) {
+      final NameIDGeneratorFactory nameIDGeneratorFactory,
+      final Saml2ServiceProviderFilter serviceProviderFilter) {
     this(eventPublisher, signatureValidator, assertionConsumerServiceValidator, replayValidator,
-        encryptCapabilitiesValidator, requestedAttributesProcessors, nameIDGeneratorFactory, null, null);
+        encryptCapabilitiesValidator, requestedAttributesProcessors, nameIDGeneratorFactory, serviceProviderFilter,
+        null, null);
   }
 
   /**
@@ -138,6 +144,7 @@ public class Saml2AuthnRequestAuthenticationProvider implements AuthenticationPr
    * @param requestedAttributesProcessors extracts the requested attributes
    * @param nameIDGeneratorFactory the {@link NameIDGeneratorFactory} to use when creating a {@link NameIDGenerator}
    *     instance
+   * @param serviceProviderFilter filter for checking whether a SP is acceptable
    * @param signatureMessageExtensionExtractor extracts the {@code SignMessage} extension (may be {@code null})
    * @param principalSelectionProcessor extracts the {@code PrincipalSelection} attribute values (may be
    *     {@code null})
@@ -150,6 +157,7 @@ public class Saml2AuthnRequestAuthenticationProvider implements AuthenticationPr
       final AuthnRequestValidator encryptCapabilitiesValidator,
       final List<RequestedAttributeProcessor> requestedAttributesProcessors,
       final NameIDGeneratorFactory nameIDGeneratorFactory,
+      final Saml2ServiceProviderFilter serviceProviderFilter,
       final SignatureMessageExtensionExtractor signatureMessageExtensionExtractor,
       final PrincipalSelectionProcessor principalSelectionProcessor) {
 
@@ -164,6 +172,8 @@ public class Saml2AuthnRequestAuthenticationProvider implements AuthenticationPr
         .orElseThrow(() -> new IllegalArgumentException("At least one RequestedAttributeProcessor must be given"));
     this.nameIDGeneratorFactory =
         Objects.requireNonNull(nameIDGeneratorFactory, "nameIDGeneratorFactory must not be null");
+    this.serviceProviderFilter =
+        Objects.requireNonNull(serviceProviderFilter, "serviceProviderFilter must not be null");
     this.signatureMessageExtensionExtractor = signatureMessageExtensionExtractor;
     this.principalSelectionProcessor = principalSelectionProcessor;
   }
@@ -202,6 +212,13 @@ public class Saml2AuthnRequestAuthenticationProvider implements AuthenticationPr
     // If encrypted assertions are required. Make sure the peer has such a cert ...
     //
     this.encryptCapabilitiesValidator.validate(token);
+
+    // Apply the SP filter to see if this SP is acceptable ...
+    //
+    if (!this.serviceProviderFilter.test(token.getPeerMetadata())) {
+      log.info("SP '{}' is not allowed by configuration [{}]", token.getEntityId(), token.getLogString());
+      throw new Saml2ErrorStatusException(Saml2ErrorStatus.NOT_AUTHORIZED);
+    }
 
     // Check the requested NameIDPolicy, and if correct, set up a NameIDGenerator ...
     //

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2ServiceProviderFilter.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2ServiceProviderFilter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.spring.saml.idp.authnrequest;
+
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+
+import java.util.function.Predicate;
+
+/**
+ * A {@link Predicate} that tells whether a SAML Service Provider sending an authentication request is accepted. The
+ * predicate will be applied after the request has been fully validated. The primary purpose for the filter is that
+ * Identity Providers wishing to restrict its services to only some SP:s within a federation can do so.
+ *
+ * @author Martin Lindström
+ */
+public interface Saml2ServiceProviderFilter extends Predicate<EntityDescriptor> {
+}

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/error/Saml2ErrorStatus.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/error/Saml2ErrorStatus.java
@@ -87,7 +87,7 @@ public enum Saml2ErrorStatus {
       "Unknown principal"),
 
   /**
-   * Missing key descriptor for encryption of assertions. 
+   * Missing key descriptor for encryption of assertions.
    */
   ENCRYPT_NOT_POSSIBLE(StatusCode.REQUESTER, StatusCode.REQUEST_DENIED, "idp.error.status.no-encrypt-capabilities",
       "Missing key descriptor for encryption"),
@@ -96,7 +96,13 @@ public enum Saml2ErrorStatus {
    * Invalid UserMessage extension.
    */
   INVALID_USER_MESSAGE(StatusCode.REQUESTER, StatusCode.REQUEST_UNSUPPORTED, "idp.error.status.invalid-user-message",
-      "Invalid UserMessage extension");
+      "Invalid UserMessage extension"),
+
+  /**
+   * SP is not allowed by to IdP policy.
+   */
+  NOT_AUTHORIZED(StatusCode.RESPONDER, StatusCode.AUTHN_FAILED, "idp.error.status.not-authorized",
+      "Not authorized to send requests");
 
   /**
    * Gets the main status code.
@@ -126,8 +132,8 @@ public enum Saml2ErrorStatus {
   }
 
   /**
-   * Gets the status message to use if no text can be resolved using the {@code statusMessageCode}
-   *ß
+   * Gets the status message to use if no text can be resolved using the {@code statusMessageCode} ß
+   *
    * @return the default status message
    */
   public String getDefaultStatusMessage() {
@@ -139,9 +145,10 @@ public enum Saml2ErrorStatus {
    *
    * @param statusCode the main status code
    * @param subStatusCode the subordinate status code
-   * @param statusMessageCode the message code to use when resolving the status message against a {@link MessageSource}
+   * @param statusMessageCode the message code to use when resolving the status message against a
+   *     {@link MessageSource}
    * @param defaultStatusMessage the status message to use if no text can be resolved using the
-   *          {@code statusMessageCode}
+   *     {@code statusMessageCode}
    */
   Saml2ErrorStatus(
       final String statusCode, final String subStatusCode,

--- a/saml-identity-provider/src/main/resources/idp-errors/idp-error-messages.properties
+++ b/saml-identity-provider/src/main/resources/idp-errors/idp-error-messages.properties
@@ -26,4 +26,4 @@ idp.error.status.no-authn-context=Requested authentication context(s) not suppor
 idp.error.status.unknown-principal=Unknown principal
 idp.error.status.no-encrypt-capabilities=Missing key descriptor for encryption
 idp.error.status.invalid-user-message=Invalid UserMessage extension
-
+idp.error.status.not-authorized=Not authorized to send requests

--- a/samples/client/pom.xml
+++ b/samples/client/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.swedenconnect.spring.saml.idp</groupId>
     <artifactId>spring-saml-idp-samples-parent</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Spring SAML Identity Provider :: Samples :: Client Application</name>

--- a/samples/demo-boot-idp/pom.xml
+++ b/samples/demo-boot-idp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.swedenconnect.spring.saml.idp</groupId>
     <artifactId>spring-saml-idp-samples-parent</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Spring SAML Identity Provider :: Samples :: Spring Boot Starter Demo Application</name>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.swedenconnect.spring.saml.idp</groupId>
     <artifactId>spring-saml-idp-parent</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Spring SAML Identity Provider :: Samples :: Parent POM</name>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>se.swedenconnect.spring.saml.idp</groupId>
     <artifactId>spring-saml-idp-parent</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Spring SAML Identity Provider :: Spring Boot Starter</name>


### PR DESCRIPTION
By implementing the `Saml2ServiceProviderFilter` interface and declaring it as a bean, an implementation can now implement whitelisting of SP:s, or apply any additional checks before accepting an authentication request.

Closes #79 