### PR TITLE
IS-85 It is now possible to use Spring SSL Bundles to specify TLS trust

### DIFF
--- a/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/MetadataProviderConfigurationProperties.java
+++ b/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/MetadataProviderConfigurationProperties.java
@@ -37,6 +37,16 @@ public class MetadataProviderConfigurationProperties {
   private Resource location;
 
   /**
+   * If the {@code location} is an HTTPS resource, this setting may be used to specify a
+   * <a href="https://spring.io/blog/2023/06/07/securing-spring-boot-applications-with-ssl">Spring SSL Bundle</a> that
+   * gives the {@link javax.net.ssl.TrustManager}s to use during TLS verification. If no bundle is given, the Java trust
+   * default will be used.
+   */
+  @Setter
+  @Getter
+  private String httpsTrustBundle;
+
+  /**
    * If the {@code location} is an HTTPS resource, this setting tells whether to skip hostname verification in the TLS
    * connection (useful during testing).
    */

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,7 @@ See https://github.com/swedenconnect/credentials-support for details about the [
 | Property | Description | Type | Default value |
 | :--- | :--- | :--- | :--- |
 | `location` | The location of the metadata. Can be an URL, a file, or even a classpath resource. | [Resource](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/Resource.html) | - |
+| `https-trust-bundle` | If `location` is an HTTPS resource, this setting may be used to specify a [Spring SSL Bundle](https://spring.io/blog/2023/06/07/securing-spring-boot-applications-with-ssl) that specifies the trusted root certificates to be used for TLS server certificate verification. If no bundle is given, the Java trust defaults will be used. | String | - |
 | `backup-location` | If the `location` setting is an URL, a "backup location" may be assigned to store downloaded metadata. | [File](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/File.html) | - |
 | `mdq` | If the `location` setting is an URL, setting the MDQ-flag means that the metadata MDQ (https://www.ietf.org/id/draft-young-md-query-17.html) protocol is used. | Boolean | `false` |
 | `validation-certificate` | The certificate used to validate the metadata. | [Resource](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/Resource.html) pointing at the certificate resource. | - |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,8 @@ Date: ---
 
 - Support for the eIDAS (optional) attributes Nationality, CountryOfResidence, CountryOfBirth and TownOfBirth was added to attribute conversion logic. This fix only applies to IdP:s that proxy assertions from eIDAS.
 
+- When configuring an HTTPS Metadata Provider it is now possible to configure it with a `https-trust-bundle` to specify which root certificates that are accepted during TLS server certificate validation. See [Metadata Provider Configuration](https://docs.swedenconnect.se/saml-identity-provider/configuration.html#metadata-provider-configuration).
+
 ### Version 2.2.0
 
 Date: 2024-10-04

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpConfigurer.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpConfigurer.java
@@ -139,8 +139,9 @@ public class Saml2IdpConfigurer extends AbstractHttpConfigurer<Saml2IdpConfigure
       httpSecurity.setSharedObject(MetadataResolver.class, metadataResolver);
     }
     else {
-      metadataResolver =
-          MetadataProviderUtils.createMetadataResolver(identityProviderSettings.getMetadataProviderConfiguration());
+      metadataResolver = MetadataProviderUtils.createMetadataResolver(
+          identityProviderSettings.getMetadataProviderConfiguration(),
+          Saml2IdpConfigurerUtils.getSslBundles(httpSecurity));
       httpSecurity.setSharedObject(MetadataResolver.class, metadataResolver);
     }
 

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpConfigurerUtils.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpConfigurerUtils.java
@@ -15,10 +15,13 @@
  */
 package se.swedenconnect.spring.saml.idp.config.configurers;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.opensaml.storage.ReplayCache;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.MessageSource;
@@ -226,6 +229,25 @@ class Saml2IdpConfigurerUtils {
     httpSecurity.setSharedObject(MessageReplayChecker.class, checker);
 
     return checker;
+  }
+
+  /**
+   * Gets the {@link SslBundles} bean
+   *
+   * @param httpSecurity the HTTP security object
+   * @return a {@link SslBundles} bean or {@code null} if not available
+   */
+  @Nullable
+  static SslBundles getSslBundles(@Nonnull final HttpSecurity httpSecurity) {
+    SslBundles bundles = httpSecurity.getSharedObject(SslBundles.class);
+    if (bundles != null) {
+      return bundles;
+    }
+    bundles = getOptionalBean(httpSecurity, SslBundles.class);
+    if (bundles != null) {
+      httpSecurity.setSharedObject(SslBundles.class, bundles);
+    }
+    return bundles;
   }
 
   static <T> T getBean(final HttpSecurity httpSecurity, final Class<T> type) {

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/settings/MetadataProviderSettings.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/settings/MetadataProviderSettings.java
@@ -15,15 +15,14 @@
  */
 package se.swedenconnect.spring.saml.idp.settings;
 
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+import se.swedenconnect.spring.saml.idp.Saml2IdentityProviderVersion;
+
 import java.io.File;
 import java.io.Serial;
 import java.security.cert.X509Certificate;
 import java.util.Map;
-
-import org.springframework.core.io.Resource;
-import org.springframework.util.Assert;
-
-import se.swedenconnect.spring.saml.idp.Saml2IdentityProviderVersion;
 
 /**
  * Settings for configuring SAML metadata providers (resolvers).
@@ -57,6 +56,28 @@ public class MetadataProviderSettings extends AbstractSettings {
    */
   public Resource getLocation() {
     return this.getSetting(SAML_METADATA_PROVIDER_LOCATION);
+  }
+
+  /**
+   * If the {@code location} is an HTTPS resource, this setting may be used to specify a
+   * <a href="https://spring.io/blog/2023/06/07/securing-spring-boot-applications-with-ssl">Spring SSL Bundle</a> that
+   * gives the {@link javax.net.ssl.TrustManager}s to use during TLS verification. If no bundle is given, the Java trust
+   * default will be used.
+   */
+  public static final String SAML_METADATA_PROVIDER_HTTPS_TRUST_BUNDLE = "https-trust-bundle";
+
+  /**
+   * Gives the <a href="https://spring.io/blog/2023/06/07/securing-spring-boot-applications-with-ssl">Spring SSL
+   * Bundle</a> that gives us the TLS trust settings to use during TLS verification. If {@code null}, the Java trust
+   * default will be used.
+   * <p>
+   * Only relevant if the {@code location} is an HTTPS resource.
+   * </p>
+   *
+   * @return a name for a trust SSL bundle, or {@code null} if not assigned
+   */
+  public String getHttpsTrustBundle() {
+    return this.getSetting(SAML_METADATA_PROVIDER_HTTPS_TRUST_BUNDLE);
   }
 
   /**
@@ -171,6 +192,21 @@ public class MetadataProviderSettings extends AbstractSettings {
      */
     public Builder location(final Resource location) {
       return this.setting(SAML_METADATA_PROVIDER_LOCATION, location);
+    }
+
+    /**
+     * Assigns the <a href="https://spring.io/blog/2023/06/07/securing-spring-boot-applications-with-ssl">Spring SSL
+     * Bundle</a> that gives us the TLS trust settings to use during TLS verification. If not specified, the Java trust
+     * default will be used.
+     * <p>
+     * Only relevant if the {@code location} is an HTTPS resource.
+     * </p>
+     *
+     * @param httpsTrustBundle name for a trust SSL bundle
+     * @return the builder
+     */
+    public Builder httpsTrustBundle(final String httpsTrustBundle) {
+      return this.setting(SAML_METADATA_PROVIDER_HTTPS_TRUST_BUNDLE, httpsTrustBundle);
     }
 
     /**


### PR DESCRIPTION
It is now possible to use Spring SSL Bundles to specify TLS trust for HTTP based metadata providers.

Closes #85 