### PR TITLE
IS-132 Support for mdorgext:OrganizationNumber` metadata extension.

### DIFF
--- a/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/IdentityProviderAutoConfiguration.java
+++ b/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/IdentityProviderAutoConfiguration.java
@@ -191,6 +191,7 @@ public class IdentityProviderAutoConfiguration {
             .names(this.properties.getMetadata().getOrganization().getNames())
             .displayNames(this.properties.getMetadata().getOrganization().getDisplayNames())
             .urls(this.properties.getMetadata().getOrganization().getUrls())
+            .number(this.properties.getMetadata().getOrganization().getNumber())
             .build());
       }
 

--- a/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/IdentityProviderConfigurationProperties.java
+++ b/autoconfigure/src/main/java/se/swedenconnect/spring/saml/idp/autoconfigure/settings/IdentityProviderConfigurationProperties.java
@@ -402,7 +402,7 @@ public class IdentityProviderConfigurationProperties implements InitializingBean
     /**
      * Whether {@code alg:DigestMethod} elements should be placed in an {@code Extensions} element under the role
      * descriptor (i.e., the {@code IDPSSODescriptor}). If {@code false}, the {@code alg:DigestMethod} elements are
-     * included as elements in the {@code Extensions} element of the {@code EntityDescriptor}.
+     * included as elements in the {@code Extensions} element of the {@code EntityDescriptor}.
      */
     @Setter
     @Getter
@@ -413,20 +413,19 @@ public class IdentityProviderConfigurationProperties implements InitializingBean
      */
     @Setter
     @Getter
-    private List<SigningMethod>
-        signingMethods;
+    private List<SigningMethod> signingMethods;
 
     /**
      * Whether {@code alg:SigningMethod} elements should be placed in an {@code Extensions} element under the role
      * descriptor (i.e., the {@code IDPSSODescriptor}). If {@code false}, the {@code alg:SigningMethod} elements are
-     * included as elements in the {@code Extensions} element of the {@code EntityDescriptor}.
+     * included as elements in the {@code Extensions} element of the {@code EntityDescriptor}.
      */
     @Setter
     @Getter
     private boolean includeSigningMethodsUnderRole;
 
     /**
-     * The {@code md:EncryptionMethod} elements that should be included under the {@code md:KeyDescriptor} for the
+     * The {@code md:EncryptionMethod} elements that should be included under the {@code md:KeyDescriptor} for the
      * encryption key. Note that these algorithms must match the configured encryption key.
      */
     @Setter
@@ -619,6 +618,11 @@ public class IdentityProviderConfigurationProperties implements InitializingBean
        * The {@code OrganizationURL}. The map key is the language tag and value is display name for that language.
        */
       private Map<String, String> urls;
+
+      /**
+       * The mdorgext:OrganizationNumber holding an organization number.
+       */
+      private String number;
     }
 
     /**

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,9 @@ thread safe. See https://github.com/swedenconnect/saml-identity-provider/issues/
 - Fixed bad error message when AuthnRequest does not contain an Issuer. See
   https://github.com/swedenconnect/saml-identity-provider/issues/125.
 
+- Added support for configuring the `mdorgext:OrganizationNumber` metadata extension.
+See https://docs.swedenconnect.se/schemas/authn/1.0/OrganizationNumber-1.0.xsd.
+
 - Dependency updates.
 
 #### Version 2.3.10

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpMetadataEndpointConfigurer.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpMetadataEndpointConfigurer.java
@@ -74,6 +74,7 @@ import se.swedenconnect.opensaml.sweid.saml2.authn.psc.RequestedPrincipalSelecti
 import se.swedenconnect.opensaml.sweid.saml2.authn.psc.build.MatchValueBuilder;
 import se.swedenconnect.opensaml.sweid.saml2.authn.psc.build.RequestedPrincipalSelectionBuilder;
 import se.swedenconnect.opensaml.sweid.saml2.metadata.entitycategory.EntityCategoryConstants;
+import se.swedenconnect.opensaml.sweid.saml2.metadata.ext.OrganizationNumber;
 import se.swedenconnect.security.credential.opensaml.OpenSamlCredential;
 import se.swedenconnect.spring.saml.idp.attributes.nameid.NameIDGeneratorFactory;
 import se.swedenconnect.spring.saml.idp.authentication.provider.UserAuthenticationProvider;
@@ -423,6 +424,17 @@ public class Saml2IdpMetadataEndpointConfigurer extends AbstractSaml2Configurer 
                 .map(e -> new LocalizedString(e.getValue(), e.getKey()))
                 .collect(Collectors.toList()))
             .orElse(null));
+
+        if (StringUtils.hasText(settings.getMetadata().getOrganization().getNumber())) {
+          final OrganizationNumber number =
+              (OrganizationNumber) XMLObjectSupport.buildXMLObject(OrganizationNumber.DEFAULT_ELEMENT_NAME);
+          number.setValue(settings.getMetadata().getOrganization().getNumber());
+
+          final Extensions orgext = (Extensions) XMLObjectSupport.buildXMLObject(Extensions.DEFAULT_ELEMENT_NAME);
+          orgext.getUnknownXMLObjects().add(number);
+
+          b.object().setExtensions(orgext);
+        }
 
         this.entityDescriptorBuilder.organization(b.build());
       }

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/settings/MetadataSettings.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/settings/MetadataSettings.java
@@ -15,15 +15,14 @@
  */
 package se.swedenconnect.spring.saml.idp.settings;
 
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+import se.swedenconnect.spring.saml.idp.Saml2IdentityProviderVersion;
+
 import java.io.Serial;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.core.io.Resource;
-import org.springframework.util.Assert;
-
-import se.swedenconnect.spring.saml.idp.Saml2IdentityProviderVersion;
 
 /**
  * Settings for the IdP metadata.
@@ -1072,12 +1071,26 @@ public class MetadataSettings extends AbstractSettings {
     public static final String URLS = "urls";
 
     /**
-     * Gets the Organization URL:s as a map where the key is the language tag and the URL the value.
+     * Gets the Organization URL:s as a map where the key is the language tag and the URL the value.
      *
      * @return a map of Organization URLs
      */
     public Map<String, String> getUrls() {
       return this.getSetting(URLS);
+    }
+
+    /**
+     * The organization number, see https://docs.swedenconnect.se/schemas/authn/1.0/OrganizationNumber-1.0.xsd.
+     */
+    public static final String NUMBER = "number";
+
+    /**
+     * Gets the organization name extension.
+     *
+     * @return a string
+     */
+    public String getNumber() {
+      return this.getSetting(NUMBER);
     }
 
     /**
@@ -1131,13 +1144,23 @@ public class MetadataSettings extends AbstractSettings {
       }
 
       /**
-       * Assigns the Organization URL:s as a map where the key is the language tag and the URL the value.
+       * Assigns the Organization URL:s as a map where the key is the language tag and the URL the value.
        *
        * @param urls a map of Organization URLs
        * @return the builder
        */
       public Builder urls(final Map<String, String> urls) {
         return this.setting(URLS, urls);
+      }
+
+      /**
+       * Assigns the organization number.
+       *
+       * @param number the organization number
+       * @return the builder
+       */
+      public Builder number(final String number) {
+        return this.setting(NUMBER, number);
       }
 
       /** {@inheritDoc} */
@@ -1159,8 +1182,8 @@ public class MetadataSettings extends AbstractSettings {
    * ContactPerson types.
    * <p>
    * Note: The {@code security} type is non-standard and defined by
-   * <a href="https://wiki.refeds.org/display/STAN/Security+Contact+Metadata+Extension+Schema">REFEDS - Security Contact
-   * Metadata Extension Schema</a>
+   * <a href="https://wiki.refeds.org/display/STAN/Security+Contact+Metadata+Extension+Schema">REFEDS - Security
+   * Contact Metadata Extension Schema</a>
    * </p>
    */
   public enum ContactPersonType {


### PR DESCRIPTION
See https://docs.swedenconnect.se/schemas/authn/1.0/OrganizationNumber-1.0.xsd.

Closes #132 