### PR TITLE
Improve Support for Runtime IdP Configuration Changes

### DIFF
--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authentication/provider/AbstractUserAuthenticationProvider.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authentication/provider/AbstractUserAuthenticationProvider.java
@@ -15,6 +15,7 @@
  */
 package se.swedenconnect.spring.saml.idp.authentication.provider;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,6 +26,8 @@ import org.springframework.security.core.Authentication;
 import lombok.extern.slf4j.Slf4j;
 import se.swedenconnect.spring.saml.idp.authentication.Saml2UserAuthentication;
 import se.swedenconnect.spring.saml.idp.authentication.Saml2UserAuthenticationInputToken;
+import se.swedenconnect.spring.saml.idp.context.Saml2IdpContext;
+import se.swedenconnect.spring.saml.idp.context.Saml2IdpContextHolder;
 import se.swedenconnect.spring.saml.idp.error.Saml2ErrorStatus;
 import se.swedenconnect.spring.saml.idp.error.Saml2ErrorStatusException;
 
@@ -117,6 +120,8 @@ public abstract class AbstractUserAuthenticationProvider implements UserAuthenti
       return null;
     }
 
+    updateSsoDurationLimit();
+
     SsoVoter.Vote currentVote = SsoVoter.Vote.DONT_KNOW;
     for (final SsoVoter voter : this.ssoVoters) {
       final SsoVoter.Vote vote = voter.mayReuse(userAuth, token, authnContextUris);
@@ -159,6 +164,24 @@ public abstract class AbstractUserAuthenticationProvider implements UserAuthenti
    */
   public List<SsoVoter> ssoVoters() {
     return this.ssoVoters;
+  }
+
+  /**
+   * Updates the first SSO voter's duration limit in accordance with IdP settings
+   */
+  protected void updateSsoDurationLimit() {
+    final SsoVoter voter = this.ssoVoters.get(0);
+    if (!(voter instanceof BaseSsoVoter)) {
+      return;
+    }
+
+    final Saml2IdpContext context = Saml2IdpContextHolder.getContext();
+    if (context == null) {
+      return;
+    }
+
+    final Duration ssoLimit = context.getSettings().getSsoDurationLimit();
+    ((BaseSsoVoter) voter).setSsoDurationLimit(ssoLimit);
   }
 
 }

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/MessageLifetimeSecurityHandler.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/MessageLifetimeSecurityHandler.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.swedenconnect.spring.saml.idp.authnrequest;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.annotation.Nonnull;
+
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.messaging.handler.AbstractMessageHandler;
+import org.opensaml.messaging.handler.MessageHandlerException;
+import org.opensaml.saml.common.messaging.context.SAMLMessageInfoContext;
+
+import lombok.extern.slf4j.Slf4j;
+import net.shibboleth.shared.logic.Constraint;
+
+/**
+ * Security message handler implementation that checks for validity of SAML message issue instant date and time.
+ *
+ * Adapted from org.opensaml.saml.common.binding.security.impl.
+ */
+@Slf4j
+public class MessageLifetimeSecurityHandler extends AbstractMessageHandler {
+
+    /**
+     * Clock skew adjustment in both directions to consider still acceptable (Default value: 3 minutes).
+     */
+    @Nonnull private Duration clockSkew;
+
+    /** Amount of time for which a message is valid after it is issued (Default value: 3 minutes). */
+    @Nonnull private Duration messageLifetime;
+
+    /** Whether this rule is required to be met. */
+    private boolean requiredRule;
+
+    /** Constructor. */
+    public MessageLifetimeSecurityHandler() {
+        clockSkew = Duration.ofMinutes(3);
+        messageLifetime = Duration.ofMinutes(3);
+        requiredRule = true;
+    }
+
+    /**
+     * Get the clock skew.
+     *
+     * @return the clock skew
+     */
+    @Nonnull public Duration getClockSkew() {
+        return clockSkew;
+    }
+
+    /**
+     * Set the clock skew.
+     *
+     * @param skew clock skew to set
+     */
+    public void setClockSkew(@Nonnull final Duration skew) {
+        // checkSetterPreconditions();
+
+        clockSkew = Constraint.isNotNull(skew, "Clock skew cannot be null");
+    }
+
+    /**
+     * Gets the amount of time for which a message is valid.
+     *
+     * @return amount of time for which a message is valid
+     */
+    @Nonnull public Duration getMessageLifetime() {
+        return messageLifetime;
+    }
+
+    /**
+     * Sets the amount of time for which a message is valid.
+     *
+     * @param lifetime amount of time for which a message is valid
+     */
+    public synchronized void setMessageLifetime(@Nonnull final Duration lifetime) {
+        // checkSetterPreconditions();
+        Constraint.isNotNull(lifetime, "Lifetime cannot be null");
+        Constraint.isFalse(lifetime.isNegative(), "Lifetime cannot be negative");
+
+        messageLifetime = lifetime;
+    }
+
+    /**
+     * Gets whether this rule is required to be met.
+     *
+     * @return whether this rule is required to be met
+     */
+    public boolean isRequiredRule() {
+        return requiredRule;
+    }
+
+    /**
+     * Sets whether this rule is required to be met.
+     *
+     * @param required whether this rule is required to be met
+     */
+    public void setRequiredRule(final boolean required) {
+        // checkSetterPreconditions();
+
+        requiredRule = required;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void doInvoke(@Nonnull final MessageContext messageContext) throws MessageHandlerException {
+        final SAMLMessageInfoContext msgInfoContext = messageContext.ensureSubcontext(SAMLMessageInfoContext.class);
+
+        final Instant issueInstant = msgInfoContext.getMessageIssueInstant();
+        if (issueInstant == null) {
+            if (requiredRule) {
+                log.warn("{} Inbound SAML message issue instant not present in message context", getLogPrefix());
+                throw new MessageHandlerException("Inbound SAML message issue instant not present in message context");
+            }
+            return;
+        }
+
+        final Instant now = Instant.now();
+        final Instant latestValid = now.plus(getClockSkew().abs());
+        final Instant expiration = issueInstant.plus(getClockSkew().abs()).plus(getMessageLifetime());
+
+        // Check message wasn't issued in the future
+        if (issueInstant.isAfter(latestValid)) {
+            log.warn("{} Message was not yet valid: message time was {}, latest valid is: {}", getLogPrefix(),
+                    issueInstant, latestValid);
+            throw new MessageHandlerException("Message was rejected because it was issued in the future");
+        }
+
+        // Check message has not expired
+        if (expiration.isBefore(now)) {
+            log.warn(
+                    "{} Message was expired: message time was '{}', message expired at: '{}', current time: '{}'",
+                    getLogPrefix(), issueInstant, expiration, now);
+            throw new MessageHandlerException("Message was rejected due to issue instant expiration");
+        }
+    }
+
+}

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2AuthnRequestAuthenticationConverter.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2AuthnRequestAuthenticationConverter.java
@@ -33,7 +33,6 @@ import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.common.binding.BindingDescriptor;
 import org.opensaml.saml.common.binding.SAMLBindingSupport;
 import org.opensaml.saml.common.binding.decoding.SAMLMessageDecoder;
-import org.opensaml.saml.common.binding.security.impl.MessageLifetimeSecurityHandler;
 import org.opensaml.saml.common.binding.security.impl.ReceivedEndpointSecurityHandler;
 import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
 import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
@@ -74,6 +73,9 @@ public class Saml2AuthnRequestAuthenticationConverter implements AuthenticationC
   /** Binding descriptor for POST. */
   private final BindingDescriptor postBindingDescriptor;
 
+  /** IdP settings */
+  private final IdentityProviderSettings settings;
+
   /**
    * Message handler which checks the validity of the SAML protocol message receiver endpoint against requirements
    * indicated in the message.
@@ -97,6 +99,7 @@ public class Saml2AuthnRequestAuthenticationConverter implements AuthenticationC
   public Saml2AuthnRequestAuthenticationConverter(final MetadataResolver metadataResolver,
       final IdentityProviderSettings settings) {
     this.metadataResolver = Objects.requireNonNull(metadataResolver, "metadataResolver must not be null");
+    this.settings = settings;
 
     // Initialize the binding descriptors ...
     //
@@ -128,8 +131,8 @@ public class Saml2AuthnRequestAuthenticationConverter implements AuthenticationC
     }
     this.messageLifetimeSecurityHandler = new MessageLifetimeSecurityHandler();
     this.messageLifetimeSecurityHandler.setRequiredRule(true);
-    this.messageLifetimeSecurityHandler.setClockSkew(settings.getClockSkewAdjustment());
-    this.messageLifetimeSecurityHandler.setMessageLifetime(settings.getMaxMessageAge());
+    this.messageLifetimeSecurityHandler.setClockSkew(this.settings.getClockSkewAdjustment());
+    this.messageLifetimeSecurityHandler.setMessageLifetime(this.settings.getMaxMessageAge());
     try {
       this.messageLifetimeSecurityHandler.initialize();
     }
@@ -198,6 +201,12 @@ public class Saml2AuthnRequestAuthenticationConverter implements AuthenticationC
         log.error("{}", msg, e);
         throw new UnrecoverableSaml2IdpException(UnrecoverableSaml2IdpError.ENDPOINT_CHECK_FAILURE, msg, e, token);
       }
+
+      // Keep the message lifetime parameters updated - the settings provider may have
+      // received changes at runtime.
+      //
+      this.messageLifetimeSecurityHandler.setClockSkew(this.settings.getClockSkewAdjustment());
+      this.messageLifetimeSecurityHandler.setMessageLifetime(this.settings.getMaxMessageAge());
 
       // Check the message lifetime, i.e., that the recived message is not too old.
       //

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2AuthnRequestAuthenticationConverter.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/authnrequest/Saml2AuthnRequestAuthenticationConverter.java
@@ -99,7 +99,7 @@ public class Saml2AuthnRequestAuthenticationConverter implements AuthenticationC
   public Saml2AuthnRequestAuthenticationConverter(final MetadataResolver metadataResolver,
       final IdentityProviderSettings settings) {
     this.metadataResolver = Objects.requireNonNull(metadataResolver, "metadataResolver must not be null");
-    this.settings = settings;
+    this.settings = Objects.requireNonNull(settings, "settings must not be null");
 
     // Initialize the binding descriptors ...
     //

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpMetadataEndpointConfigurer.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/config/configurers/Saml2IdpMetadataEndpointConfigurer.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
@@ -99,6 +100,9 @@ public class Saml2IdpMetadataEndpointConfigurer extends AbstractSaml2Configurer 
   /** For customizing metadata. */
   private Customizer<EntityDescriptor> entityDescriptorCustomizer = Customizer.withDefaults();
 
+  /** For customizing metadata. */
+  private UnaryOperator<EntityDescriptorContainer> entityDescriptorContainerTransformer = (obj) -> obj;
+
   /** The metadata builder. */
   private EntityDescriptorBuilder entityDescriptorBuilder;
 
@@ -121,6 +125,19 @@ public class Saml2IdpMetadataEndpointConfigurer extends AbstractSaml2Configurer 
   public Saml2IdpMetadataEndpointConfigurer entityDescriptorCustomizer(
       final Customizer<EntityDescriptor> metadataCustomizer) {
     this.entityDescriptorCustomizer = Objects.requireNonNull(metadataCustomizer, "metadataCustomizer must not be null");
+    return this;
+  }
+
+  /**
+   * Sets the transformer providing access to the {@link EntityDescriptorContainer} allowing the ability to customize how
+   * the published IdP metadata is constructed and updated.
+   *
+   * @param metadataContainerTransformer the transformer providing access to the {@link EntityDescriptor}
+   * @return the {@link Saml2IdpMetadataEndpointConfigurer} for further configuration
+   */
+  public Saml2IdpMetadataEndpointConfigurer entityDescriptorContainerTransformer(
+      final UnaryOperator<EntityDescriptorContainer> metadataContainerTransformer) {
+    this.entityDescriptorContainerTransformer = Objects.requireNonNull(metadataContainerTransformer, "metadataContainerTransformer must not be null");
     return this;
   }
 
@@ -471,7 +488,7 @@ public class Saml2IdpMetadataEndpointConfigurer extends AbstractSaml2Configurer 
     container.setValidity(settings.getMetadata().getValidityPeriod());
 
     final Saml2IdpMetadataEndpointFilter filter =
-        new Saml2IdpMetadataEndpointFilter(container, this.requestMatcher);
+        new Saml2IdpMetadataEndpointFilter(this.entityDescriptorContainerTransformer.apply(container), this.requestMatcher);
     httpSecurity.addFilterBefore(this.postProcess(filter), AbstractPreAuthenticatedProcessingFilter.class);
   }
 

--- a/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/settings/IdentityProviderSettings.java
+++ b/saml-identity-provider/src/main/java/se/swedenconnect/spring/saml/idp/settings/IdentityProviderSettings.java
@@ -44,7 +44,7 @@ public class IdentityProviderSettings extends AbstractSettings {
    *
    * @param settings the settings
    */
-  private IdentityProviderSettings(final Map<String, Object> settings) {
+  public IdentityProviderSettings(final Map<String, Object> settings) {
     super(settings);
   }
 


### PR DESCRIPTION
Hi,

In my project, I'd like to provide an admin UI for:

1. Managing SP metadata
2. Managing PKI credentials
3. Configuring the IdP

such that multiple IdP instances are able to update their configuration without
needing a restart.

For 1 and 2, this wasn't too difficult, but for 3, I've had to add a few hacks
(included in this PR) to make changes to things like:

- SSO duration limit (this one wasn't configurable at all)
- Request lifetime
- Clock skew adjustment
- Metadata settings (including entity id)

take effect without restarting the IdP - the Customizer entry points weren't
sufficient for this.

The approach I went with is to provide a custom DB-backed
`IdentityProviderSettings` component (hence the need for a public constructor),
and use that in response and assertion customizer to keep things like IdP's
entity id in the responses up-to-date. Then for metadata, I just defined a
custom `EntityDescriptorContainer` that checks the IdP settings for changes and
gets injected via the `entityDescriptorContainerTransformer` call.

The awkward `MessageLifetimeSecurityHandler` is here because the OpenSAML one
doesn't allow runtime changes at all.

There are a few things I know I've ignored, e.g., `saml.idp-metadata-providers[].*`, 
`saml.idp.audit.*`, but I thought I'd check with you first.

Is this kind of library usage something you'd be willing to support? If so, I
think I can find some time to make some improvements.

PS Thank you for making this project and the docs public, it's a huge help.